### PR TITLE
Fix gallery filtering for partitions and railings

### DIFF
--- a/src/gallery-builder.js
+++ b/src/gallery-builder.js
@@ -5,11 +5,18 @@ export function buildGallery() {
     as: 'url',
   });
 
+  // Map singular file prefixes to the plural category names used in the HTML
+  const prefixMap = {
+    partition: 'partitions',
+    railing: 'railings',
+  };
+
   const categorized = {};
 
   for (const [path, url] of Object.entries(images)) {
     const name = path.split('/').pop() || '';
-    const prefix = name.split('_')[0].toLowerCase();
+    const rawPrefix = name.split('_')[0].toLowerCase();
+    const prefix = prefixMap[rawPrefix] || rawPrefix;
     if (!categorized[prefix]) {
       categorized[prefix] = [];
     }


### PR DESCRIPTION
## Summary
- fix plural category names in gallery builder so partition and railing images load

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68538274c818832bb5742e2d8f4ef556